### PR TITLE
feat: add intermediate models

### DIFF
--- a/snow_dbt/dbt_project.yml
+++ b/snow_dbt/dbt_project.yml
@@ -19,5 +19,7 @@ models:
   snow_dbt:
     staging:
       +materialized: view
+    intermediate:
+      +materialized: ephemeral
     marts:
       +materialized: table

--- a/snow_dbt/models/intermediate/_intermediate__models.yml
+++ b/snow_dbt/models/intermediate/_intermediate__models.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_customers_and_locations_joined
+  - name: int_order_amounts_agg_by_customer

--- a/snow_dbt/models/intermediate/int_customers_and_locations_joined.sql
+++ b/snow_dbt/models/intermediate/int_customers_and_locations_joined.sql
@@ -1,0 +1,48 @@
+with
+
+customers as (
+
+    select * from {{ ref('stg_tech_store__customers') }}
+
+),
+
+cities as (
+
+    select * from {{ ref('stg_tech_store__cities') }}
+
+),
+
+states as (
+
+    select * from {{ ref('stg_tech_store__states') }}
+
+),
+
+zip_codes as (
+
+    select * from {{ ref('stg_tech_store__zip_codes') }}
+
+),
+
+customers_and_locations_joined as (
+
+    select
+        customers.customer_id,
+        cities.city_name,
+        states.state_name,
+        zip_codes.zip_code
+
+    from customers
+
+    left join cities
+        on customers.city_id = cities.city_id
+
+    left join states
+        on cities.state_id = states.state_id
+
+    left join zip_codes
+        on cities.zip_code_id = zip_codes.zip_code_id
+
+)
+
+select * from customers_and_locations_joined

--- a/snow_dbt/models/intermediate/int_order_amounts_agg_by_customer.sql
+++ b/snow_dbt/models/intermediate/int_order_amounts_agg_by_customer.sql
@@ -1,0 +1,31 @@
+with
+
+customers as (
+
+    select * from {{ ref('stg_tech_store__customers') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('orders') }}
+
+),
+
+total_revenue_and_units_by_customer as (
+
+    select 
+        customers.customer_id,
+        sum(orders.amount_in_usd) as total_revenue_in_usd,
+        sum(orders.quantity) as total_quantity
+    
+    from orders
+
+    left join customers
+        on orders.customer_id = customers.customer_id
+
+    group by 1
+
+)
+
+select * from total_revenue_and_units_by_customer

--- a/snow_dbt/models/marts/customers.sql
+++ b/snow_dbt/models/marts/customers.sql
@@ -6,21 +6,9 @@ customers as (
 
 ),
 
-cities as (
+customers_and_locations_joined as (
 
-    select * from {{ ref('stg_tech_store__cities') }}
-
-),
-
-states as (
-
-    select * from {{ ref('stg_tech_store__states') }}
-
-),
-
-zip_codes as (
-
-    select * from {{ ref('stg_tech_store__zip_codes') }}
+    select * from {{ ref('int_customers_and_locations_joined') }}
 
 ),
 
@@ -30,32 +18,37 @@ employees as (
 
 ),
 
+order_amounts_by_customer as (
+
+    select * from {{ ref('int_order_amounts_agg_by_customer') }}
+
+),
+
 final as (
 
     select
         customers.customer_id,
         customers.customer_name,
-        cities.city_name,
-        states.state_name,
-        zip_codes.zip_code,
+        customers_and_locations_joined.city_name,
+        customers_and_locations_joined.state_name,
+        customers_and_locations_joined.zip_code,
         employees.full_name as main_employee,
+        nvl(order_amounts_by_customer.total_revenue_in_usd, 0) as total_revenue_in_usd,
+        nvl(order_amounts_by_customer.total_quantity, 0) as total_quantity,
         customers.created_at,
         customers.updated_at,
         customers.is_active
 
     from customers
 
-    left join cities
-        on customers.city_id = cities.city_id
-
-    left join states
-        on cities.state_id = states.state_id
-
-    left join zip_codes
-        on cities.zip_code_id = zip_codes.zip_code_id
+    left join customers_and_locations_joined
+        on customers.customer_id = customers_and_locations_joined.customer_id
 
     left join employees
         on customers.main_employee_id = employees.employee_id
+
+    left join order_amounts_by_customer
+        on customers.customer_id = order_amounts_by_customer.customer_id
 )
 
 select * from final


### PR DESCRIPTION

### Summary
Add `intermediate` models to simplify `marts` logic

### Details
Added 2 `intermediate` models:
* `int_customers_and_locations_joined` - Consolidate location data for `city`, `state` and `zip` to avoid excess joins in `marts`
* `int_order_amounts_aggregated_by_customer` - Get total sales and quantities returned on the `customer` level to be joined back to `customer` model

Updated `dbt_project.yml`
* Added new model config for `intermediate` directory
   * Set `materialized` to `ephemeral` - Results do not need to be deployed to the database server
   
### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[Intermediate Models](https://docs.getdbt.com/guides/best-practices/how-we-structure/3-intermediate)
